### PR TITLE
drop the r in the version number

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -3,7 +3,7 @@
 # -*- mode: yaml -*-
 
 jobs:
-- job: linux_64
+- job: linux
   pool:
     vmImage: ubuntu-16.04
   timeoutInMinutes: 240
@@ -29,3 +29,5 @@ jobs:
 
   - script: .azure-pipelines/run_docker_build.sh
     displayName: Run docker build
+    env:
+      BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -3,7 +3,7 @@
 # -*- mode: yaml -*-
 
 jobs:
-- job: osx_64
+- job: osx
   pool:
     vmImage: macOS-10.13
   timeoutInMinutes: 240
@@ -81,4 +81,6 @@ jobs:
       set -x -e
       upload_package ./ ./recipe ./.ci_support/${CONFIG}.yaml
     displayName: Upload recipe
+    env:
+      BINSTAR_TOKEN: $(BINSTAR_TOKEN)
     condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "7.1.0r" %}
+{% set version = "7.1.0" %}
 {% set ver = version.replace(".", "_") %}
 
 package:
@@ -10,7 +10,7 @@ source:
   git_tag: ESMF_7_1_0r
 
 build:
-  number: 1003
+  number: 1004
   skip: True  # [win]
 
 requirements:
@@ -34,8 +34,6 @@ test:
   commands:
     - ESMF_Info
     - ESMF_RegridWeightGen --help
-    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
-    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
 
 about:
   home: http://www.earthsystemmodeling.org/


### PR DESCRIPTION
Fixes https://github.com/conda-forge/esmf-feedstock/issues/35

@bekozi is it OK to just drop the `r` in the version number? That is causing errors when parsing versions b/c it is a non-standard version.

PS: is

```
  git_url: git://git.code.sf.net/p/esmf/esmf
  git_tag: ESMF_7_1_0r
```

still the best way to get the source or are there tarball releases now?