### PR TITLE
Rebuild v7.1.0 with libnetcdf 4.7.1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @bekozi @ocefpaf @rokuingh
+* @bekozi @ocefpaf @rokuingh @xylar

--- a/README.md
+++ b/README.md
@@ -159,4 +159,5 @@ Feedstock Maintainers
 * [@bekozi](https://github.com/bekozi/)
 * [@ocefpaf](https://github.com/ocefpaf/)
 * [@rokuingh](https://github.com/rokuingh/)
+* [@xylar](https://github.com/xylar/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "8.0.0" %}
+{% set version = "7.1.0" %}
 {% set ver = version.replace(".", "_") %}
 
 package:
@@ -7,10 +7,10 @@ package:
 
 source:
   git_url: git://git.code.sf.net/p/esmf/esmf
-  git_tag: ESMF_8_0_0
+  git_tag: ESMF_7_1_0r
 
 build:
-  number: 1
+  number: 1009
   skip: True  # [win]
 
 requirements:
@@ -47,3 +47,4 @@ extra:
     - ocefpaf
     - bekozi
     - rokuingh
+    - xylar


### PR DESCRIPTION
I'm working on a package that seemingly isn't ready for esmf/esmpy 8.0.0 (some of its dependencies pin esmpy 7.1.0).  Also, esmpy 8.0.0 hasn't been built successfully yet.  

However, through other dependencies, they now need libnetcdf 4.7.1.  So I'm hoping we can build esmf 7.1.0 with that version.

I have requested that I be added as a maintainer.  I would revert the recipe back to 8.0.0 after this merge (and increment the build number).

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
