### PR TITLE
Rebuild for hdf5 1.14.1

### DIFF
--- a/.ci_support/linux_64_mpimpich.yaml
+++ b/.ci_support/linux_64_mpimpich.yaml
@@ -19,7 +19,7 @@ fortran_compiler:
 fortran_compiler_version:
 - '12'
 hdf5:
-- 1.14.0
+- 1.14.1
 libnetcdf:
 - 4.9.2
 mpi:

--- a/.ci_support/linux_64_mpinompi.yaml
+++ b/.ci_support/linux_64_mpinompi.yaml
@@ -19,7 +19,7 @@ fortran_compiler:
 fortran_compiler_version:
 - '12'
 hdf5:
-- 1.14.0
+- 1.14.1
 libnetcdf:
 - 4.9.2
 mpi:

--- a/.ci_support/linux_64_mpiopenmpi.yaml
+++ b/.ci_support/linux_64_mpiopenmpi.yaml
@@ -19,7 +19,7 @@ fortran_compiler:
 fortran_compiler_version:
 - '12'
 hdf5:
-- 1.14.0
+- 1.14.1
 libnetcdf:
 - 4.9.2
 mpi:

--- a/.ci_support/linux_aarch64_mpimpich.yaml
+++ b/.ci_support/linux_aarch64_mpimpich.yaml
@@ -23,7 +23,7 @@ fortran_compiler:
 fortran_compiler_version:
 - '12'
 hdf5:
-- 1.14.0
+- 1.14.1
 libnetcdf:
 - 4.9.2
 mpi:

--- a/.ci_support/linux_aarch64_mpinompi.yaml
+++ b/.ci_support/linux_aarch64_mpinompi.yaml
@@ -23,7 +23,7 @@ fortran_compiler:
 fortran_compiler_version:
 - '12'
 hdf5:
-- 1.14.0
+- 1.14.1
 libnetcdf:
 - 4.9.2
 mpi:

--- a/.ci_support/linux_aarch64_mpiopenmpi.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpi.yaml
@@ -23,7 +23,7 @@ fortran_compiler:
 fortran_compiler_version:
 - '12'
 hdf5:
-- 1.14.0
+- 1.14.1
 libnetcdf:
 - 4.9.2
 mpi:

--- a/.ci_support/linux_ppc64le_mpimpich.yaml
+++ b/.ci_support/linux_ppc64le_mpimpich.yaml
@@ -19,7 +19,7 @@ fortran_compiler:
 fortran_compiler_version:
 - '12'
 hdf5:
-- 1.14.0
+- 1.14.1
 libnetcdf:
 - 4.9.2
 mpi:

--- a/.ci_support/linux_ppc64le_mpinompi.yaml
+++ b/.ci_support/linux_ppc64le_mpinompi.yaml
@@ -19,7 +19,7 @@ fortran_compiler:
 fortran_compiler_version:
 - '12'
 hdf5:
-- 1.14.0
+- 1.14.1
 libnetcdf:
 - 4.9.2
 mpi:

--- a/.ci_support/linux_ppc64le_mpiopenmpi.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpi.yaml
@@ -19,7 +19,7 @@ fortran_compiler:
 fortran_compiler_version:
 - '12'
 hdf5:
-- 1.14.0
+- 1.14.1
 libnetcdf:
 - 4.9.2
 mpi:

--- a/.ci_support/migrations/hdf51140.yaml
+++ b/.ci_support/migrations/hdf51140.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-hdf5:
-- 1.14.0
-migrator_ts: 1675622758

--- a/.ci_support/migrations/hdf51141.yaml
+++ b/.ci_support/migrations/hdf51141.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+hdf5:
+- 1.14.1
+migrator_ts: 1687165815.3104627

--- a/.ci_support/osx_64_mpimpich.yaml
+++ b/.ci_support/osx_64_mpimpich.yaml
@@ -17,7 +17,7 @@ fortran_compiler:
 fortran_compiler_version:
 - '12'
 hdf5:
-- 1.14.0
+- 1.14.1
 libnetcdf:
 - 4.9.2
 macos_machine:

--- a/.ci_support/osx_64_mpinompi.yaml
+++ b/.ci_support/osx_64_mpinompi.yaml
@@ -17,7 +17,7 @@ fortran_compiler:
 fortran_compiler_version:
 - '12'
 hdf5:
-- 1.14.0
+- 1.14.1
 libnetcdf:
 - 4.9.2
 macos_machine:

--- a/.ci_support/osx_64_mpiopenmpi.yaml
+++ b/.ci_support/osx_64_mpiopenmpi.yaml
@@ -17,7 +17,7 @@ fortran_compiler:
 fortran_compiler_version:
 - '12'
 hdf5:
-- 1.14.0
+- 1.14.1
 libnetcdf:
 - 4.9.2
 macos_machine:

--- a/.ci_support/osx_arm64_mpimpich.yaml
+++ b/.ci_support/osx_arm64_mpimpich.yaml
@@ -17,7 +17,7 @@ fortran_compiler:
 fortran_compiler_version:
 - '12'
 hdf5:
-- 1.14.0
+- 1.14.1
 libnetcdf:
 - 4.9.2
 macos_machine:

--- a/.ci_support/osx_arm64_mpinompi.yaml
+++ b/.ci_support/osx_arm64_mpinompi.yaml
@@ -17,7 +17,7 @@ fortran_compiler:
 fortran_compiler_version:
 - '12'
 hdf5:
-- 1.14.0
+- 1.14.1
 libnetcdf:
 - 4.9.2
 macos_machine:

--- a/.ci_support/osx_arm64_mpiopenmpi.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpi.yaml
@@ -17,7 +17,7 @@ fortran_compiler:
 fortran_compiler_version:
 - '12'
 hdf5:
-- 1.14.0
+- 1.14.1
 libnetcdf:
 - 4.9.2
 macos_machine:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -3,7 +3,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 hdf5:
-- 1.14.0
+- 1.14.1
 libnetcdf:
 - 4.9.2
 m2w64_c_compiler:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "8.4.2" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 # ensure mpi is defined (needed for conda-smithy recipe-lint)
 {% set mpi = mpi or 'nompi' %}


### PR DESCRIPTION
Manually migrating because the bot doesn't seemed to have noticed the merge of conda-forge/libnetcdf-feedstock#177

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
