### PR TITLE
Fix linker flags

### DIFF
--- a/.ci_support/linux_64_mpimpich.yaml
+++ b/.ci_support/linux_64_mpimpich.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
+- '2.12'
 cdt_name:
 - cos6
 channel_sources:

--- a/.ci_support/linux_64_mpinompi.yaml
+++ b/.ci_support/linux_64_mpinompi.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
+- '2.12'
 cdt_name:
 - cos6
 channel_sources:

--- a/.ci_support/linux_64_mpiopenmpi.yaml
+++ b/.ci_support/linux_64_mpiopenmpi.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
+- '2.12'
 cdt_name:
 - cos6
 channel_sources:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -78,6 +78,9 @@ if [[ $(uname) == Darwin ]]; then
   export LDFLAGS="-headerpad_max_install_names -Wl,-no_compact_unwind $LDFLAGS"
   export ESMF_F90LINKOPTS="$LDFLAGS -pthread -lc++"
   export ESMF_CXXLINKOPTS="$LDFLAGS -pthread"
+else
+  export ESMF_F90LINKOPTS="$LDFLAGS"
+  export ESMF_CXXLINKOPTS="$LDFLAGS"
 fi
 
 make -j${CPU_COUNT}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -74,6 +74,7 @@ elif [[ $mpi == 'nompi' ]]; then
   export ESMF_COMM=mpiuni
 fi
 
+export ESMF_CLINKOPTS="$LDFLAGS"
 if [[ $(uname) == Darwin ]]; then
   export LDFLAGS="-headerpad_max_install_names -Wl,-no_compact_unwind $LDFLAGS"
   export ESMF_F90LINKOPTS="$LDFLAGS -pthread -lc++"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,6 +3,3 @@ mpi:
   - mpich  # [not win]
   - openmpi  # [not win]
 
-# needed to avoid issue in https://github.com/conda-forge/openmpi-feedstock/issues/143
-c_stdlib_version:
-  - 2.17  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "8.6.1" %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 # ensure mpi is defined (needed for conda-smithy recipe-lint)
 {% set mpi = mpi or 'nompi' %}


### PR DESCRIPTION
This should allow us to no longer constrain `c_stdlib_version`

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
